### PR TITLE
Revert "Volume buttons support (#334)" (#338)

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -107,18 +107,6 @@ super + {_,shift +} bracketright
 super + {_,shift +} bracketleft
 	lmc back {10,120}
 
-# General bindings for audio control buttons. You might also want
-# to specify your @DEFAULT_SINK@ in /etc/pulse/default.pa
-# Mute volume
-XF86AudioMute
-	pactl set-sink-mute @DEFAULT_SINK@ toggle
-# Decrease volume
-XF86AudioLowerVolume
-	pactl set-sink-volume @DEFAULT_SINK@ -5%
-# Increase volume
-XF86AudioRaiseVolume
-	pactl set-sink-volume @DEFAULT_SINK@ +5%
-
 # Function keys
 # Show readme
 super + F1


### PR DESCRIPTION
This reverts commit 6d136d4fdd9f9a3c24e278cb9d863a6ea61ebbba.
Volume and other media keys were added in d4bcaf9de80d27f0c4bd5f4d96f1eb546783feda using lmc tool that updates the i3blocks volume module
removing this to avoid conflict and unnecessary bindings